### PR TITLE
include krane

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,6 +22,7 @@ _install_crane() {
 
   echo "Unpacking crane to bin directory"
   tar -C "${_install_path}/bin" -zxf "${ASDF_DOWNLOAD_PATH}/${_artifact}" crane
+  tar -C "${_install_path}/bin" -zxf "${ASDF_DOWNLOAD_PATH}/${_artifact}" krane
 
   chmod +x "${_install_path}"/bin
 }


### PR DESCRIPTION
Krane is counter part to crane that is identical but supports kubernetes/cloud work load identity auth providers. https://github.com/google/go-containerregistry/blob/main/cmd/krane/README.md

Its in the same package thats already downloaded, this PR just extracts it along with crane. It seems sensible to wrap this in your provider rather than contribute a second provider.